### PR TITLE
Don't allow user to remove own admin rights

### DIFF
--- a/Handler/UserUpdate.hs
+++ b/Handler/UserUpdate.hs
@@ -58,7 +58,12 @@ userForm ident user mcurrentUser = renderSematnicUiDivs $ User
                 Just (Entity _ currentUser) ->
                         if (userAdmin currentUser)
                             then
-                                field
+                                -- Don't allow user to remove own admin rights.
+                                if (userIdent currentUser == userIdent user)
+                                    then
+                                        pure val
+                                    else
+                                        field
                             else
                                 pure val
 

--- a/templates/user.hamlet
+++ b/templates/user.hamlet
@@ -2,6 +2,10 @@
     <h1>
         #{userIdent user}
 
+        $if (userAdmin user)
+            <span class="ui blue horizontal label">
+                Admin
+
     $maybe localTasks <- mlocalTasks
         ^{localTasks}
 

--- a/test/Handler/UserUpdateSpec.hs
+++ b/test/Handler/UserUpdateSpec.hs
@@ -29,4 +29,14 @@ spec = withApp $ do
             adminUser <- createAdminUser "bar"
             authenticateAs adminUser
             get $ UserUpdateR "foo"
+
             statusIs 200
+            htmlAnyContain ".ui.form .field label" "Admin"
+
+        it "asserts admin user cannot uncheck admin own rights" $ do
+            adminUser <- createAdminUser "bar"
+            authenticateAs adminUser
+            get $ UserUpdateR "bar"
+
+            statusIs 200
+            bodyNotContains "Admin"


### PR DESCRIPTION
When admin user edits own profile, they will not see the admin checkbox